### PR TITLE
Added support for C#

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Ruby: `_spec.rb`
 | Name | Default |
 | -- | -- |
 | `testFinder.showInStatusBar` | `false` |
+| `testFinder.csharpGlob` | `Tests.cs` |
 | `testFinder.javascriptGlob` | `-test.js` |
 | `testFinder.rubyGlob` | `_spec.rb` |
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
         "configuration": {
             "title": "Spec Finder Configuration",
             "properties": {
+                "testFinder.csharpGlob": {
+                    "type": "string",
+                    "default": "Tests.cs",
+                    "description": "Find C# files using this glob appended to current file name"
+                },
                 "testFinder.javascriptGlob": {
                     "type": "string",
                     "default": "-test.js",


### PR DESCRIPTION
Very simple change to add support for C# test files. From general research it appears most tests follow the convention of simply appending the word "Tests" to the end of the original class/controller/file name.

Tested on my local machine with a simple C# project.