### PR TITLE
Add setting for opening in split view or current view

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Add the extension via the [VS Code marketpalce](https://marketplace.visualstudio
 | Name | Default | Description
 | -- | -- | -- |
 | `testFinder.showInStatusBar` | `false` | Shows a message on the left side of the status  bar to indicate whether it has found the test file or not
+| `testFinder.openInSplitView` | `true` | Open test file in split view or current window
 | `testFinder.csharpGlob` | `Tests.cs` | Default for C# files (ex: Foo.cs has test file FooTests.cs)
 | `testFinder.javascriptGlob` | `-test.js` | Default for JavaScript files (ex: foo.js has test file foo-test.js)
 | `testFinder.rubyGlob` | `_spec.rb` | Default for Ruby files (ex: foo.rb has test foo_spec.rb)

--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Show spec file found in status bar"
+                },
+                "testFinder.openInSplitView": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Open test file in split view or current window"
                 }
             }
         },

--- a/src/test-file-finder.ts
+++ b/src/test-file-finder.ts
@@ -42,7 +42,7 @@ export default class SpecFileFinder {
       }
 
       workspace.openTextDocument(files[0]).then((doc: TextDocument) => {
-        window.showTextDocument(doc, ViewColumn.Beside, false);
+        window.showTextDocument(doc, this.getViewColumnToOpenTestFile(), false);
       });
     });
   }
@@ -61,6 +61,12 @@ export default class SpecFileFinder {
       });
 
     return globConfiguration;
+  }
+
+  private getViewColumnToOpenTestFile(): ViewColumn {
+    const splitViewConfig = workspace.getConfiguration('testFinder').get('openInSplitView');
+
+    return splitViewConfig ? ViewColumn.Beside : ViewColumn.Active;
   }
 
   private _parseFileName(fileName: string): string | null {


### PR DESCRIPTION
This PR adds the setting `testFinder.openInSplitView` with the default value being `true`.

**Addresses feature request in Issue #6**
## openInSplitView
### `true`
![splitviewon](https://user-images.githubusercontent.com/20227290/46631616-eca83b00-cb15-11e8-929c-f290d73ca4c7.gif)
### `false`
![splitviewsettingoff](https://user-images.githubusercontent.com/20227290/46631621-f5007600-cb15-11e8-8e75-61dd6dc43155.gif)

